### PR TITLE
Add GitHub Action to build and test

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  ubuntu-20-gcc:
+  gcc-mpich:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
         cd test
         make runtest
 
-  ubuntu-20-intel:
+  intel-oneapi:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -8,9 +8,7 @@ on:
 jobs:
 
   build:
-
     runs-on: ubuntu-20.04
-
     steps:
     - uses: actions/checkout@v3
     - name: Update and install dependencies
@@ -21,6 +19,37 @@ jobs:
       env:
         YVERSION: 3
         YFAMILY: gnu
+        YMPICXX: mpicxx
+      run: |
+        ./configure -i ../install
+        make
+        make install
+    - name: Test YogiMPI
+      run: |
+        cd test
+        make runtest
+
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update and install dependencies
+      run: |
+        # From https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2023-0/install-using-package-managers.html
+        # download the key to system keyring
+        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+        | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+        # add signed entry to apt sources and configure the APT client to use
+        # Intel repository:
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        # install deps and intel
+        sudo apt install -y cmake pkg-config build-essential intel-basekit intel-hpckit
+        # activate intel oneapi
+        . /opt/intel/oneapi/setvars.sh
+    - name: Build YogiMPI
+      env:
+        YVERSION: 3
+        YFAMILY: intel
         YMPICXX: mpicxx
       run: |
         ./configure -i ../install

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -43,6 +43,7 @@ jobs:
         # add signed entry to apt sources and configure the APT client to use
         # Intel repository:
         echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt update
         # install deps and intel
         sudo apt install -y cmake pkg-config build-essential intel-basekit intel-hpckit
         # activate intel oneapi

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,33 @@
+name: Docker Image CI
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update and install dependencies
+      run: |
+        sudo apt-get install -y build-essential
+        sudo apt install -y mpich
+    - name: Build YogiMPI
+      env:
+        YVERSION: 3
+        YFAMILY: gnu
+        YMPICXX: mpicxx
+      run: |
+        ./configure -i ../install
+        make
+        make install
+    - name: Test YogiMPI
+      run: |
+        cd test
+        make runtest
+

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  build:
+  ubuntu-20.04_gcc:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -29,6 +29,7 @@ jobs:
         cd test
         make runtest
 
+  ubuntu-20.04_intel:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,13 +52,13 @@ jobs:
         YFAMILY: intel
         YMPICXX: mpicxx
       run: |
-        # activate intel oneapi
         . /opt/intel/oneapi/setvars.sh
         ./configure -i ../install
         make
         make install
     - name: Test YogiMPI
       run: |
+        . /opt/intel/oneapi/setvars.sh
         cd test
         make runtest
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -46,14 +46,14 @@ jobs:
         sudo apt update
         # install deps and intel
         sudo apt install -y cmake pkg-config build-essential intel-basekit intel-hpckit
-        # activate intel oneapi
-        . /opt/intel/oneapi/setvars.sh
     - name: Build YogiMPI
       env:
         YVERSION: 3
         YFAMILY: intel
         YMPICXX: mpicxx
       run: |
+        # activate intel oneapi
+        . /opt/intel/oneapi/setvars.sh
         ./configure -i ../install
         make
         make install

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
 
-  ubuntu-20.04_gcc:
+  ubuntu-20-gcc:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
         cd test
         make runtest
 
-  ubuntu-20.04_intel:
+  ubuntu-20-intel:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
This pull request adds a [GitHub action](https://docs.github.com/en/actions) to automate the building and testing process for YogiMPI, defined in `.github/workflows/docker-image.yml`. It will run whenever changes are pushed to any branch, and currently takes less than a minute, building on Ubuntu 20.04 against MPICH 3.3.2 (I'm open to adding other build targets in the future).

Please review and let me know if you have any concerns about this pull request.