### PR TITLE
GitHub action to build and test

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,10 +7,8 @@ on:
 
 jobs:
 
-  build:
-
+  gcc-mpich:
     runs-on: ubuntu-20.04
-
     steps:
     - uses: actions/checkout@v3
     - name: Update and install dependencies
@@ -28,6 +26,39 @@ jobs:
         make install
     - name: Test YogiMPI
       run: |
+        cd test
+        make runtest
+
+  intel-oneapi:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update and install dependencies
+      run: |
+        # From https://www.intel.com/content/www/us/en/docs/oneapi/installation-guide-linux/2023-0/install-using-package-managers.html
+        # download the key to system keyring
+        wget -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+        | gpg --dearmor | sudo tee /usr/share/keyrings/oneapi-archive-keyring.gpg > /dev/null
+
+        # add signed entry to apt sources and configure the APT client to use
+        # Intel repository:
+        echo "deb [signed-by=/usr/share/keyrings/oneapi-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | sudo tee /etc/apt/sources.list.d/oneAPI.list
+        sudo apt update
+        # install deps and intel
+        sudo apt install -y cmake pkg-config build-essential intel-basekit intel-hpckit
+    - name: Build YogiMPI
+      env:
+        YVERSION: 3
+        YFAMILY: intel
+        YMPICXX: mpicxx
+      run: |
+        . /opt/intel/oneapi/setvars.sh
+        ./configure -i ../install
+        make
+        make install
+    - name: Test YogiMPI
+      run: |
+        . /opt/intel/oneapi/setvars.sh
         cd test
         make runtest
 

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,33 @@
+name: Docker Image CI
+
+on:
+  push:
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Update and install dependencies
+      run: |
+        sudo apt-get install -y build-essential
+        sudo apt install -y mpich
+    - name: Build YogiMPI
+      env:
+        YVERSION: 3
+        YFAMILY: gnu
+        YMPICXX: mpicxx
+      run: |
+        ./configure -i ../install
+        make
+        make install
+    - name: Test YogiMPI
+      run: |
+        cd test
+        make runtest
+


### PR DESCRIPTION
Sorry about the confusion, when I was rebasing I accidentally closed the [previous pr](https://github.com/DOD-HPCMP-CREATE/yogimpi/pull/2). I can't reopen it because I temporarily deleted the remote branch.

This pull request adds a [GitHub action](https://docs.github.com/en/actions) to automate the building and testing process for YogiMPI, defined in .github/workflows/docker-image.yml. It builds against against MPICH 3.3.2 and Intel MPI.