### PR TITLE
Updates for compatibility with hdf5 1.14.6

### DIFF
--- a/src/WrapMPI.xml
+++ b/src/WrapMPI.xml
@@ -1057,7 +1057,7 @@ if (comm_delete_attr_keep) {manPrefix}delAttrFn(*comm_keyval, comm_delete_attr_k
   </Function>
   <Function name="MPI_Get_address">
     <ReturnType>int</ReturnType>
-    <Arg input="true" name="location" type="void*"/>
+    <Arg input="true" name="location" type="const void*"/>
     <Arg name="address" output="true" type="MPI_Aint*"/>
   </Function>
   <Function name="MPI_Get_count">

--- a/src/YogiManager.cxx
+++ b/src/YogiManager.cxx
@@ -249,6 +249,9 @@ YogiManager::YogiManager() {
     datatypePool.at(YogiMPI_C_LONG_DOUBLE_COMPLEX) = MPI_C_LONG_DOUBLE_COMPLEX;
     datatypePool.at(YogiMPI_AINT)              = MPI_AINT;
     datatypePool.at(YogiMPI_OFFSET)            = MPI_OFFSET;
+#if YogiMPI_VERSION == 3
+    datatypePool.at(YogiMPI_COUNT)             = MPI_COUNT;
+#endif
 
 #if YogiMPI_VERSION == 3
     datatypePool.at(YogiMPI_CXX_BOOL)            = MPI_CXX_BOOL;

--- a/src/YogiManager.cxx
+++ b/src/YogiManager.cxx
@@ -34,7 +34,7 @@ YogiManager::YogiManager() {
     opPool.resize(defaultPoolSize, MPI_OP_NULL);
     numOps = opOffset = 15;
     datatypePool.resize(defaultPoolSize, MPI_DATATYPE_NULL);
-    numDatatypes = datatypeOffset = 56;
+    numDatatypes = datatypeOffset = 57;
     infoPool.resize(defaultPoolSize, MPI_INFO_NULL);
     numInfos = infoOffset = 1;
     groupPool.resize(defaultPoolSize, MPI_GROUP_NULL);

--- a/src/mpitoyogi.h.in
+++ b/src/mpitoyogi.h.in
@@ -253,6 +253,9 @@
 
 #define MPI_AINT YogiMPI_AINT
 #define MPI_OFFSET YogiMPI_OFFSET
+#if YogiMPI_VERSION == 3
+#define MPI_COUNT YogiMPI_COUNT
+#endif
 
 #define MPI_COMM_WORLD YogiMPI_COMM_WORLD
 #define MPI_COMM_SELF YogiMPI_COMM_SELF

--- a/src/yogimpi.h.in
+++ b/src/yogimpi.h.in
@@ -287,26 +287,30 @@ typedef int YogiMPI_Message;
 /* MPI 2.2 types that are needed for MPI I/O */
 #define YogiMPI_AINT 45
 #define YogiMPI_OFFSET 46
+/* May be Fortran-only and not relegated to IO, but this often flocks with OFFSET. */
+#if YogiMPI_VERSION == 3
+#define YogiMPI_COUNT 47
+#endif
 
 /* These should probably be with the above "Optional datatypes (C)", */
 /* but they were added later so putting them here to avoid reordering the list. */
-#define YogiMPI_INT8_T 47
-#define YogiMPI_INT16_T 48
+#define YogiMPI_INT8_T 48
+#define YogiMPI_INT16_T 49
 
 /* MPI 3 defined C++ types */
 #if YogiMPI_VERSION == 3
-#define YogiMPI_CXX_BOOL 49
-#define YogiMPI_CXX_FLOAT_COMPLEX 50
-#define YogiMPI_CXX_DOUBLE_COMPLEX 51
-#define YogiMPI_CXX_LONG_DOUBLE_COMPLEX 52
+#define YogiMPI_CXX_BOOL 50
+#define YogiMPI_CXX_FLOAT_COMPLEX 51
+#define YogiMPI_CXX_DOUBLE_COMPLEX 52
+#define YogiMPI_CXX_LONG_DOUBLE_COMPLEX 53
 #endif
 
 /* MPI Unsigned Integer Types. */
 /* I kept breaking things when I tried to weave these in earlier */
-#define YogiMPI_UINT8_T 53
-#define YogiMPI_UINT16_T 54
-#define YogiMPI_UINT32_T 55
-#define YogiMPI_UINT64_T 56
+#define YogiMPI_UINT8_T 54
+#define YogiMPI_UINT16_T 55
+#define YogiMPI_UINT32_T 56
+#define YogiMPI_UINT64_T 57
 
 /* reserved communicators (C and Fortran) */
 #define YogiMPI_COMM_WORLD 1

--- a/src/yogimpi.h.in
+++ b/src/yogimpi.h.in
@@ -287,30 +287,30 @@ typedef int YogiMPI_Message;
 /* MPI 2.2 types that are needed for MPI I/O */
 #define YogiMPI_AINT 45
 #define YogiMPI_OFFSET 46
-/* May be Fortran-only and not relegated to IO, but this often flocks with OFFSET. */
-#if YogiMPI_VERSION == 3
-#define YogiMPI_COUNT 47
-#endif
 
 /* These should probably be with the above "Optional datatypes (C)", */
 /* but they were added later so putting them here to avoid reordering the list. */
-#define YogiMPI_INT8_T 48
-#define YogiMPI_INT16_T 49
+#define YogiMPI_INT8_T 47
+#define YogiMPI_INT16_T 48
 
 /* MPI 3 defined C++ types */
 #if YogiMPI_VERSION == 3
-#define YogiMPI_CXX_BOOL 50
-#define YogiMPI_CXX_FLOAT_COMPLEX 51
-#define YogiMPI_CXX_DOUBLE_COMPLEX 52
-#define YogiMPI_CXX_LONG_DOUBLE_COMPLEX 53
+#define YogiMPI_CXX_BOOL 49
+#define YogiMPI_CXX_FLOAT_COMPLEX 50
+#define YogiMPI_CXX_DOUBLE_COMPLEX 51
+#define YogiMPI_CXX_LONG_DOUBLE_COMPLEX 52
 #endif
 
 /* MPI Unsigned Integer Types. */
 /* I kept breaking things when I tried to weave these in earlier */
-#define YogiMPI_UINT8_T 54
-#define YogiMPI_UINT16_T 55
-#define YogiMPI_UINT32_T 56
-#define YogiMPI_UINT64_T 57
+#define YogiMPI_UINT8_T 53
+#define YogiMPI_UINT16_T 54
+#define YogiMPI_UINT32_T 55
+#define YogiMPI_UINT64_T 56
+
+#if YogiMPI_VERSION == 3
+#define YogiMPI_COUNT 57
+#endif
 
 /* reserved communicators (C and Fortran) */
 #define YogiMPI_COMM_WORLD 1

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,7 +25,7 @@ endif
 
 c2tests: simple createOp errorHandler nonBlocking probe testAll writeFile1 \
          waitany collective sendrecv testComms nonblock_waitall waitsome \
-         testAttr testInfo testFileModes
+         testAttr testInfo testFileModes types
 
 c3tests: mprobe
 
@@ -83,6 +83,9 @@ waitsome: waitsome.c
 testAttr: testAttr.c
 	$(YCC) $(CFLAGS) $(DEBUGFLAGS) testAttr.c -o testAttr
 
+types: types.c
+	$(YCC) $(CFLAGS) $(DEBUGFLAGS) types.c -o types
+
 runc3tests: c3tests
 	./testRunner.sh 2 ./mprobe
 
@@ -104,6 +107,7 @@ runc2tests: c2tests
 	./testRunner.sh 4 ./testAttr
 	./testRunner.sh 4 ./testInfo
 	./testRunner.sh 2 ./testFileModes
+	./testRunner.sh 4 ./types
 
 runftests: ftests
 	./testRunner.sh 2 ./fsimple
@@ -154,7 +158,7 @@ ftests: fwriteFile1 fsendrecv fcollective ftestComms f_gatherscatter \
 clean:
 	$(RM) *.o nonBlocking sendrecv fsendrecv simple testCancelled \
               writeFile1 fwriteFile1 f_gatherscatter fnonblock \
-              nonblock_waitall testComms fsimple testInfo \
+              nonblock_waitall testComms fsimple testInfo types \
               ftestComms probe mprobe collective fcollective fwtick \
               waitsome waitany fwaitsome createOp errorHandler testAll \
               cWriteFile.result fWriteFile.result testAttr ftestInfo \

--- a/test/types.c
+++ b/test/types.c
@@ -1,0 +1,61 @@
+// Transmit data of different types using their associated datatype constants.
+
+#include "mpi.h"
+#include <assert.h>
+
+void test_INT(MPI_Comm comm, int rank, int exp) {
+    int send = rank;
+    int recv = -1;
+    MPI_Allreduce(&send, &recv, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+    assert(recv == exp);
+}
+
+void test_LONG(MPI_Comm comm, int rank, int exp) {
+    long int send = rank;
+    long int recv = -1;
+    MPI_Allreduce(&send, &recv, 1, MPI_LONG, MPI_SUM, MPI_COMM_WORLD);
+    assert(recv == (long int)exp);
+}
+
+void test_FLOAT(MPI_Comm comm, int rank, int exp) {
+    float send = (float)rank;
+    float recv = -1.0;
+    MPI_Allreduce(&send, &recv, 1, MPI_FLOAT, MPI_SUM, MPI_COMM_WORLD);
+    assert(recv == (float)exp);
+}
+
+void test_DOUBLE(MPI_Comm comm, int rank, int exp) {
+    double send = (double)rank;
+    double recv = -1.0;
+    MPI_Allreduce(&send, &recv, 1, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
+    assert(recv == (double)exp);
+}
+
+void test_COUNT(MPI_Comm comm, int rank, int exp) {
+    MPI_Count send = (MPI_Count)rank;
+    MPI_Count recv = -1.0;
+    MPI_Allreduce(&send, &recv, 1, MPI_COUNT, MPI_SUM, MPI_COMM_WORLD);
+    assert(recv == (MPI_Count)exp);
+}
+
+int main(int argc, char *argv[]) {
+    int rank = -1;
+    int size = -1;
+    MPI_Init(&argc,&argv);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+    int exp = 0;
+    for (int i=0; i<size; ++i) {
+        exp = exp + i;
+    }
+
+    test_INT(MPI_COMM_WORLD, rank, exp);
+    test_LONG(MPI_COMM_WORLD, rank, exp);
+    test_FLOAT(MPI_COMM_WORLD, rank, exp);
+    test_DOUBLE(MPI_COMM_WORLD, rank, exp);
+    test_COUNT(MPI_COMM_WORLD, rank, exp);
+
+    MPI_Finalize();
+    return 0;
+}

--- a/wrapper/YogiMPIWrapper.py.in
+++ b/wrapper/YogiMPIWrapper.py.in
@@ -40,7 +40,7 @@ class YogiMPIWrapper(object):
     # The regular expression to find instances of use mpi in a Fortran file.
     # This is a newer Fortran 90 style that deprecates the "include 'mpif.h'"
     # We look for both.
-    useMPIRegEx = re.compile(r"([\s]*)use[\s]+mpi([\s]*)", re.IGNORECASE)
+    useMPIRegEx = re.compile(r"([\s]*)use[\s]+mpi([\s,])", re.IGNORECASE)
     # Regular expression to find instances of command line preprocessor
     # definitions which have quoted values.
 

--- a/wrapper/YogiMPIWrapper.py.in
+++ b/wrapper/YogiMPIWrapper.py.in
@@ -40,7 +40,7 @@ class YogiMPIWrapper(object):
     # The regular expression to find instances of use mpi in a Fortran file.
     # This is a newer Fortran 90 style that deprecates the "include 'mpif.h'"
     # We look for both.
-    useMPIRegEx = re.compile(r"([\s]*)use[\s]+mpi([\s]+)", re.IGNORECASE)
+    useMPIRegEx = re.compile(r"([\s]*)use[\s]+mpi([\s]*)", re.IGNORECASE)
     # Regular expression to find instances of command line preprocessor
     # definitions which have quoted values.
 


### PR DESCRIPTION
1. The `MPI_Count` type was defined but not the associated datatype constant (`MPI_COUNT`).  This has been added.
2. Fixed the signature for `MPI_Get_address()` to make `location` const.
3. Fixed the regex used to replace `use mpi` with 'use yogimpi' in Fortran.  It required space after 'mpi', which failed to find usage where only certain symbols are imported (e.g. `use mpi, only: MPI_INTEGER`).

This is my first real change in yogi, so do not hesitate to point out all the things I may have missed.  I have tested these changes against the avtools 0.38 branch with GCC 12.2 and Intel 2021.8.0.